### PR TITLE
generate-sysfs-overlay: remove usage of sed

### DIFF
--- a/glue/bin/generate-sysfs-overlay
+++ b/glue/bin/generate-sysfs-overlay
@@ -30,8 +30,10 @@ else
             if [ -z "${2}" ]; then
                 echo "Missing target directory"
                 print_help
-            else 
-                generate_sysfs_overlay | sed -e 's/^/sysfs_overlay='"${2}"'; /' | xargs -I {} bash -c "{}"
+            else
+                export sysfs_overlay=$(realpath "${2}")
+                generate_sysfs_overlay | xargs -I {} bash -c "{}"
+                unset sysfs_overlay
             fi
             ;;
         *)


### PR DESCRIPTION
Removing sed allows the use of full paths for the sysfs_overlay, as any sed delimiter could be used in the path name, breaking the output.

This resolves https://github.com/kubiko/toolbox/issues/2
