### PR TITLE
lxd_snapcraft: replaced method of getting user ID with more robust `id -u`

### DIFF
--- a/glue/usr/bin/snapcraft-lxd-wrapper
+++ b/glue/usr/bin/snapcraft-lxd-wrapper
@@ -45,14 +45,6 @@ print_help_lxd_snapcraft () {
   echo -e "\t\$ lxd_snapcraft prime --target-arch=armhf"
   echo -e "\t\$ lxd_snapcraft armhf prime"
 }
-uid() {
-  user="${1:-"$USER"}"
-  while IFS=':' read -r uname x uid etc; do
-    if [ "$uname" = "$user" ]; then
-      echo "$uid"
-    fi
-  done
-}
 
 lxd_ensure_ssh_setup () {
   # get ssh keys ready
@@ -289,8 +281,15 @@ lxd_ensure_container () {
     [ -e "${tmp_sources_deb822}" ] && rm "${tmp_sources_deb822}"
   fi
 
-  cuid="0" # root
-  lxc config set "${container_name}" raw.idmap "both $(uid "${USER}" < /etc/passwd) ${cuid}"
+  if [ -z "$USER" ]; then
+    echo "USER variable is not set" >&2
+    return 1
+  fi
+
+  userid="$(id -u "$USER")"
+  groupid="0" # root
+
+  lxc config set "${container_name}" raw.idmap "both ${userid} ${groupid}"
   # check if kernel version is 5.x, enough to enable mknod interception, to support debootstrap
   # we cannot enable it for all the kernels, container would refuse to boot
   if [ "$(uname -a | awk '{print $3}' | awk -F . '{print $1}')" -ge 5 ]; then


### PR DESCRIPTION
When creating a new container with `lxd_snapcraft`, the script fetches the user ID on the host with `uid "${USER}" < /etc/passwd` and maps it to `raw.idmap` with `lxc`.

When the user ID on the host is "sufficiently high", the current method fails, and the two important folders `host` and `.ssh` are mounted as `nobody:nogroup`. This breaks the `lxd_snapcraft` functionality that relies on sending commands through SSH (the keys are no longer accessible by the SSH server inside the container. Logging in with `lxc shell <container name>` doesn't work either since the `host` directory containing the files required is not accessible.

The user ID is now retrieved with the more common and robust alternative `id -u "${USER}"`, which works even with a high user ID on the host.

This has been superficially tested by running a couple of different snap builds with base `core20` and `core24`. More rigorous testing can be performed if necessary ;)

Edit: the problem is not the high UID, but rather the user being absent from `/etc/passwd`. In the latest commit I have also added a check for `$USER` actually being set, rather than having a default '1' that would cause the same issue with the dirs mounted inside the container.