### PR TITLE
lxd_snapcraft: allow comments at the end of line for 'base' field

### DIFF
--- a/glue/usr/bin/set-path
+++ b/glue/usr/bin/set-path
@@ -13,8 +13,10 @@ echo "export PATH=\"\${SNAP_PATH}/usr/bin:\${SNAP_PATH}/usr/sbin:\${PATH}\"" >&2
 echo "export PATH=\"\${SNAP_PATH}/usr/bin:\${SNAP_PATH}/usr/sbin:\${PATH}\""
 echo "export LD_LIBRARY_PATH=\"/usr/lib:/usr/lib/${ARCH_TRIPLET}:\${SNAP_PATH}/usr/lib:\${SNAP_PATH}/usr/lib/${ARCH_TRIPLET}\"" >&2
 echo "export LD_LIBRARY_PATH=\"/usr/lib:/usr/lib/${ARCH_TRIPLET}:\${SNAP_PATH}/usr/lib:\${SNAP_PATH}/usr/lib/${ARCH_TRIPLET}\""
-echo "alias ssudo='sudo -E env \"PATH=\$PATH\" \"LD_LIBRARY_PATH=\$LD_LIBRARY_PATH\"'" >&2
-echo "alias ssudo='sudo -E env \"PATH=\$PATH\" \"LD_LIBRARY_PATH=\$LD_LIBRARY_PATH\"'"
+echo "export PERL5LIB=\"\${SNAP_PATH}/usr/lib/${ARCH_TRIPLET}/perl:\${SNAP_PATH}/usr/lib/${ARCH_TRIPLET}/perl-base:\${SNAP_PATH}/usr/share/perl\"" >&2
+echo "export PERL5LIB=\"\${SNAP_PATH}/usr/lib/${ARCH_TRIPLET}/perl:\${SNAP_PATH}/usr/lib/${ARCH_TRIPLET}/perl-base:\${SNAP_PATH}/usr/share/perl\""
+echo "alias ssudo='sudo -E env \"PATH=\$PATH\" \"PERL5LIB=\$PERL5LIB\" \"LD_LIBRARY_PATH=\$LD_LIBRARY_PATH\"'" >&2
+echo "alias ssudo='sudo -E env \"PATH=\$PATH\" \"PERL5LIB=\$PERL5LIB\" \"LD_LIBRARY_PATH=\$LD_LIBRARY_PATH\"'"
 echo "alias sudo='ssudo '" >&2
 echo "alias sudo='ssudo '"
 echo "export XDG_DATA_DIRS=/usr/local/share:/usr/share:/snap/snapd/current/usr/share:\${SNAP_PATH}/usr/share" >&2

--- a/glue/usr/bin/snapcraft-lxd-wrapper
+++ b/glue/usr/bin/snapcraft-lxd-wrapper
@@ -470,7 +470,7 @@ lxd_snapcraft () {
     # use build-base and then base as means to determine build series
     local base
     base=$(grep 'build-base:' "${snapcraft_yaml}" | awk '{print $2}')
-    [ -z "${base}" ] && base=$(awk -F ':' '{if ($1 == "base") {gsub(/[[:blank:]]/,"");print $2}}' "${snapcraft_yaml}" )
+    [ -z "${base}" ] && base=$(grep '^base:' "${snapcraft_yaml}" | awk '{print $2}')
     case ${base} in
       core16|core)
         local ubuntu_series="xenial"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,11 +15,10 @@ grade: stable
 architectures:
   - build-on: armhf
   - build-on: arm64
-  - build-on: i386
   - build-on: amd64
   - build-on: ppc64el
 
-base: core18
+base: core20
 
 environment:
   PATH:            $SNAP/usr/sbin:$SNAP/usr/bin:$PATH

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,7 +19,7 @@ architectures:
   - build-on: ppc64el
   - build-on: riscv64
 
-base: core20
+base: core22
 
 environment:
   PATH:            ${SNAP}/usr/sbin:${SNAP}/usr/bin:$PATH

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,6 +17,7 @@ architectures:
   - build-on: arm64
   - build-on: amd64
   - build-on: ppc64el
+  - build-on: riscv64
 
 base: core20
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -210,11 +210,8 @@ parts:
     plugin: autotools
     source: https://github.com/alobbs/macchanger.git
     source-type: git
-    configflags:
+    autotools-configure-parameters:
       - --datadir=/snap/${SNAPCRAFT_PROJECT_NAME}/current/usr/share/
-    override-build: |
-      ./autogen.sh
-      snapcraftctl build
     organize:
       snap/${SNAPCRAFT_PROJECT_NAME}/current/usr/share/: usr/share/
     stage:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,19 +12,18 @@ description: |
 
 confinement: strict
 grade: stable
-architectures:
-  - build-on: armhf
-  - build-on: arm64
-  - build-on: amd64
-  - build-on: ppc64el
-  - build-on: riscv64
+platforms:
+  armhf:
+  arm64:
+  amd64:
+  riscv64:
 
-base: core22
+base: core24
 
 environment:
   PATH:            ${SNAP}/usr/sbin:${SNAP}/usr/bin:$PATH
-  LD_LIBRARY_PATH: ${SNAP_LIBRARY_PATH}:${LD_LIBRARY_PATH}:${SNAP}/lib:${SNAP}/usr/lib:${SNAP}/lib/${CRAFT_ARCH_TRIPLET}:${SNAP}/usr/lib/${CRAFT_ARCH_TRIPLET}
-  ARCH_TRIPLET:    ${CRAFT_ARCH_TRIPLET}
+  LD_LIBRARY_PATH: ${SNAP_LIBRARY_PATH}:${LD_LIBRARY_PATH}:${SNAP}/lib:${SNAP}/usr/lib:${SNAP}/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}:${SNAP}/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}
+  ARCH_TRIPLET:    ${CRAFT_ARCH_TRIPLET_BUILD_FOR}
 
 apps:
   help:
@@ -74,12 +73,12 @@ parts:
       - iperf3
       - iw
       - jq
-      - libdb5.3
+      - libdb5.3t64
       - libgpm2
       - liblz4-tool
-      - libmagic1
+      - libmagic1t64
       - libonig5
-      - libparted2
+      - libparted2t64
       - libslang2
       - libubootenv-tool
       - libusb-1.0-0
@@ -274,11 +273,11 @@ parts:
     source: https://github.com/mobile-shell/mosh.git
     source-type: git
     stage-packages:
-      - libprotobuf23
+      - libprotobuf32t64
     autotools-configure-parameters:
       - --prefix=/usr
       - --bindir=/usr/bin
-      - --libdir=/usr/lib/${CRAFT_ARCH_TRIPLET}
+      - --libdir=/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}
     stage:
       - usr/bin/mosh-server
       - usr/bin/mosh
@@ -326,7 +325,6 @@ build-packages:
   - libudev-dev
   - pkg-config
   - protobuf-compiler
-  - python2.7
   - texinfo
   - wget
   - zlib1g

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -131,6 +131,9 @@ parts:
     stage:
       - -bin/bash
       - -usr/bin/py*
+      - -usr/lib/*/libdrm_*
+      - -usr/lib/*/libgallium*
+      - -usr/lib/*/libLLVM*
       - -usr/lib/gcc
       - -usr/lib/klibc*
       - -usr/lib/python3/dist-packages/R*

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -296,15 +296,15 @@ parts:
       install -D -m 0644 README.md           ${CRAFT_PART_INSTALL}/usr/doc/tiobench/README.md
       install -D -m 0644 scripts/README      ${CRAFT_PART_INSTALL}/usr/doc/tiobench/README
 
-  ioctl:
-    plugin: make
-    source: https://github.com/jerome-pouiller/ioctl.git
-    source-type: git
-    source-branch: master
-    override-build: |
-      if [ -z $(uname -a | grep "ppc64el") ]; then
-        craftctl default
-      fi
+  # ioctl:
+  #   plugin: make
+  #   source: https://github.com/jerome-pouiller/ioctl.git
+  #   source-type: git
+  #   source-branch: master
+  #   override-build: |
+  #     if [ -z $(uname -a | grep "ppc64el") ]; then
+  #       craftctl default
+  #     fi
 
 build-packages:
   - curl

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: toolbox
-version: "0.9.43"
+version: "0.9.44"
 summary: Swiss knife of shell tools
 description: |
   Set of useful shell tools to be used on Ubuntu/Ubuntu core systems.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -80,6 +80,8 @@ parts:
       - libgpm2
       - liblz4-tool
       - libmagic1
+      - libonig5
+      - libparted2
       - libslang2
       - libusb-1.0-0
       - linux-tools-common
@@ -94,6 +96,7 @@ parts:
       - nano
       - netdiscover
       - net-tools
+      - parted
       - pastebinit
       - pciutils
       - ppp
@@ -125,8 +128,7 @@ parts:
       - wireless-tools
       - xz-utils
       - zip
-      - try:
-        - libonig4
+      - on amd64,arm64,armhf:
         - sysbench
     stage:
       - -bin/bash

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -258,8 +258,8 @@ parts:
     override-pull: |
       snapcraftctl pull
       wget https://raw.githubusercontent.com/snapcore/snapd/master/include/lk/snappy_boot_common.h
-      wget https://raw.githubusercontent.com/snapcore/snapd/master/include/lk/snappy_boot_v1.h
-      wget https://raw.githubusercontent.com/kubiko/if6640-gadget/18/snap-boot-sel/lk-boot-env.c
+      wget https://raw.githubusercontent.com/snapcore/snapd/master/include/lk/snappy_boot_v2.h
+      wget https://raw.githubusercontent.com/kubiko/dragonboard-gadget/20-lk/snap-boot-sel/lk-boot-env.c
     override-build: |
       mkdir -p ${SNAPCRAFT_PART_INSTALL}/bin
       gcc lk-boot-env.c -I/usr/include/ -Iapp/aboot -o ${SNAPCRAFT_PART_INSTALL}/bin/lk-boot-env

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -52,7 +52,6 @@ parts:
       - byobu
       - cpio
       - cpu-checker
-      - cryptsetup-bin
       - curl
       - device-tree-compiler
       - devmem2

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -269,13 +269,9 @@ parts:
     source: https://github.com/mobile-shell/mosh.git
     source-type: git
     stage-packages:
-      - libprotobuf10
-    override-build: |
-      ./autogen.sh
-      snapcraftctl build
+      - libprotobuf17
     organize:
-      bin/mosh:        usr/bin/mosh
-      bin/mosh-server: usr/bin/mosh-server
+      usr/local/bin/: usr/bin/
     stage:
       - usr/bin/mosh-server
       - usr/bin/mosh

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -191,6 +191,21 @@ parts:
           -e 's|\(conf_file = "\)\(.*\)|\1/snap/toolbox/current\2|g' \
           ${SNAPCRAFT_PART_INSTALL}/usr/lib/python3/dist-packages/ssh_import_id/__init__.py
 
+  mc:
+    source: https://github.com/MidnightCommander/mc.git
+    plugin: autotools
+    configflags:
+      - --prefix=/snap/toolbox/current/usr
+      - --sysconfdir=/var/snap/toolbox/common/etc
+      - --without-x
+    override-build: |
+      ./autogen.sh
+      snapcraftctl build
+      mv ${SNAPCRAFT_PART_INSTALL}/snap/toolbox/current/usr ${SNAPCRAFT_PART_INSTALL}/
+      rm -rf ${SNAPCRAFT_PART_INSTALL}/snap
+      mv ${SNAPCRAFT_PART_INSTALL}/var/snap/toolbox/common/etc ${SNAPCRAFT_PART_INSTALL}/
+      rm -rf ${SNAPCRAFT_PART_INSTALL}/var
+
   macchanger:
     plugin: autotools
     source: https://github.com/alobbs/macchanger.git

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -82,6 +82,7 @@ parts:
       - libonig5
       - libparted2
       - libslang2
+      - libubootenv-tool
       - libusb-1.0-0
       - linux-tools-common
       - lm-sensors
@@ -114,7 +115,6 @@ parts:
       - time
       - tmux
       - tree
-      - u-boot-tools
       - unzip
       - usbutils
       - util-linux

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -195,12 +195,11 @@ parts:
   mc:
     source: https://github.com/MidnightCommander/mc.git
     plugin: autotools
-    configflags:
+    autotools-configure-parameters:
       - --prefix=/snap/toolbox/current/usr
       - --sysconfdir=/var/snap/toolbox/common/etc
       - --without-x
     override-build: |
-      ./autogen.sh
       snapcraftctl build
       mv ${SNAPCRAFT_PART_INSTALL}/snap/toolbox/current/usr ${SNAPCRAFT_PART_INSTALL}/
       rm -rf ${SNAPCRAFT_PART_INSTALL}/snap

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,8 +22,8 @@ architectures:
 base: core20
 
 environment:
-  PATH:            $SNAP/usr/sbin:$SNAP/usr/bin:$PATH
-  LD_LIBRARY_PATH: $SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH:$SNAP/usr/lib:$SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}
+  PATH:            ${SNAP}/usr/sbin:${SNAP}/usr/bin:$PATH
+  LD_LIBRARY_PATH: ${SNAP_LIBRARY_PATH}:${LD_LIBRARY_PATH}:${SNAP}/usr/lib:${SNAP}/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}
   ARCH_TRIPLET:    ${SNAPCRAFT_ARCH_TRIPLET}
 
 apps:
@@ -135,6 +135,7 @@ parts:
       - -usr/bin/perl*
       - -usr/bin/py*
       - -usr/lib/gcc
+      - -usr/lib/klibc*
       - -usr/lib/*/perl*
       - -usr/lib/*/libperl*
       - -usr/lib/python3/dist-packages/R*
@@ -192,6 +193,14 @@ parts:
       sed -i \
           -e 's|\(conf_file = "\)\(.*\)|\1/snap/toolbox/current\2|g' \
           ${SNAPCRAFT_PART_INSTALL}/usr/lib/python3/dist-packages/ssh_import_id/__init__.py
+      # merge {s}bin/,lib, to usr/{s}bin, usr/lib
+      mv ${SNAPCRAFT_PART_INSTALL}/bin/*     ${SNAPCRAFT_PART_INSTALL}/usr/bin
+      mv ${SNAPCRAFT_PART_INSTALL}/sbin/*    ${SNAPCRAFT_PART_INSTALL}/usr/sbin
+      cp -rl ${SNAPCRAFT_PART_INSTALL}/lib/* ${SNAPCRAFT_PART_INSTALL}/usr/lib
+      rm -rf ${SNAPCRAFT_PART_INSTALL}/bin   ${SNAPCRAFT_PART_INSTALL}/sbin ${SNAPCRAFT_PART_INSTALL}/lib
+      ln -sf usr/bin  ${SNAPCRAFT_PART_INSTALL}/bin
+      ln -sf usr/sbin ${SNAPCRAFT_PART_INSTALL}/sbin
+      ln -sf usr/lib  ${SNAPCRAFT_PART_INSTALL}/lib
 
   mc:
     source: https://github.com/MidnightCommander/mc.git
@@ -249,7 +258,7 @@ parts:
     override-build: |
       cp mountinfo.query ${SNAPCRAFT_PART_INSTALL}/
     organize:
-      mountinfo.query: bin/mountinfo.query
+      mountinfo.query: usr/bin/mountinfo.query
 
   lk-boot-env:
     plugin: nil
@@ -259,8 +268,8 @@ parts:
       wget https://raw.githubusercontent.com/snapcore/snapd/master/include/lk/snappy_boot_v2.h
       wget https://raw.githubusercontent.com/kubiko/dragonboard-gadget/20-lk/snap-boot-sel/lk-boot-env.c
     override-build: |
-      mkdir -p ${SNAPCRAFT_PART_INSTALL}/bin
-      gcc lk-boot-env.c -I/usr/include/ -Iapp/aboot -o ${SNAPCRAFT_PART_INSTALL}/bin/lk-boot-env
+      mkdir -p ${SNAPCRAFT_PART_INSTALL}/usr/bin
+      gcc lk-boot-env.c -I/usr/include/ -Iapp/aboot -o ${SNAPCRAFT_PART_INSTALL}/usr/bin/lk-boot-env
 
   mosh:
     plugin: autotools
@@ -268,8 +277,10 @@ parts:
     source-type: git
     stage-packages:
       - libprotobuf17
-    organize:
-      usr/local/bin/: usr/bin/
+    autotools-configure-parameters:
+      - --prefix=/usr
+      - --bindir=/usr/bin
+      - --libdir=/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}
     stage:
       - usr/bin/mosh-server
       - usr/bin/mosh
@@ -281,18 +292,12 @@ parts:
     source-type: git
     override-build: |
       make -j$(nproc)
-      mkdir -p ${SNAPCRAFT_PART_INSTALL}/bin \
-               ${SNAPCRAFT_PART_INSTALL}/usr/doc/tiobench
-      install -m 0755 tiobench.pl         ${SNAPCRAFT_PART_INSTALL}/bin/tiobench.pl
-      install -m 0755 tiotest             ${SNAPCRAFT_PART_INSTALL}/bin/tiotest
-      install -m 0755 scripts/bigbench.sh ${SNAPCRAFT_PART_INSTALL}/bin/bigbench.sh
-      install -m 0755 scripts/tiosum.pl   ${SNAPCRAFT_PART_INSTALL}/bin/tiosum.pl
-      install -m 0644 README.md           ${SNAPCRAFT_PART_INSTALL}/usr/doc/tiobench/README.md
-      install -m 0644 scripts/README      ${SNAPCRAFT_PART_INSTALL}/usr/doc/tiobench/README
-    stage:
-      - bin/tio*
-      - bin/bigbench*
-      - usr/doc/tiobench
+      install -D -m 0755 tiobench.pl         ${SNAPCRAFT_PART_INSTALL}/usr/bin/tiobench.pl
+      install -D -m 0755 tiotest             ${SNAPCRAFT_PART_INSTALL}/usr/bin/tiotest
+      install -D -m 0755 scripts/bigbench.sh ${SNAPCRAFT_PART_INSTALL}/usr/bin/bigbench.sh
+      install -D -m 0755 scripts/tiosum.pl   ${SNAPCRAFT_PART_INSTALL}/usr/bin/tiosum.pl
+      install -D -m 0644 README.md           ${SNAPCRAFT_PART_INSTALL}/usr/doc/tiobench/README.md
+      install -D -m 0644 scripts/README      ${SNAPCRAFT_PART_INSTALL}/usr/doc/tiobench/README
 
   ioctl:
     plugin: make

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,20 +23,18 @@ base: core22
 
 environment:
   PATH:            ${SNAP}/usr/sbin:${SNAP}/usr/bin:$PATH
-  LD_LIBRARY_PATH: ${SNAP_LIBRARY_PATH}:${LD_LIBRARY_PATH}:${SNAP}/usr/lib:${SNAP}/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}
-  ARCH_TRIPLET:    ${SNAPCRAFT_ARCH_TRIPLET}
+  LD_LIBRARY_PATH: ${SNAP_LIBRARY_PATH}:${LD_LIBRARY_PATH}:${SNAP}/lib:${SNAP}/usr/lib:${SNAP}/lib/${CRAFT_ARCH_TRIPLET}:${SNAP}/usr/lib/${CRAFT_ARCH_TRIPLET}
+  ARCH_TRIPLET:    ${CRAFT_ARCH_TRIPLET}
 
 apps:
   help:
     command: usr/bin/toolbox-help
-    adapter: none
 
   bash:
     command: usr/bin/bash
 
   set-path:
     command: usr/bin/set-path
-    adapter: none
 
 parts:
   tools:
@@ -157,50 +155,50 @@ parts:
       - -usr/bin/lsb_release
     override-build: |
       # first clean files from stage packages we want override
-      for f in ${SNAPCRAFT_PART_INSTALL}/usr/share/bash-completion/completions/ssh
+      for f in ${CRAFT_PART_INSTALL}/usr/share/bash-completion/completions/ssh
       do
         if [ -e ${f} ]; then
           rm -rf ${f}
         fi
       done
-      snapcraftctl build
+      craftctl default
       echo "Checking if usr/bin/peekfd exists"
       # interestingly on arm64 there is no usr/bin/peekfd, account for this
-      if [ ! -f ${SNAPCRAFT_PART_INSTALL}/usr/bin/peekfd ]; then
+      if [ ! -f ${CRAFT_PART_INSTALL}/usr/bin/peekfd ]; then
         echo "adding stub for usr/bin/peekfd"
-        echo "#!/bin/bash" > ${SNAPCRAFT_PART_INSTALL}/usr/bin/peekfd
-        echo "echo 'peekfd is not supported on arm64'" >> ${SNAPCRAFT_PART_INSTALL}/usr/bin/peekfd
-        chmod +x ${SNAPCRAFT_PART_INSTALL}/usr/bin/peekfd
+        echo "#!/bin/bash" > ${CRAFT_PART_INSTALL}/usr/bin/peekfd
+        echo "echo 'peekfd is not supported on arm64'" >> ${CRAFT_PART_INSTALL}/usr/bin/peekfd
+        chmod +x ${CRAFT_PART_INSTALL}/usr/bin/peekfd
       fi
       sed -i \
           -e 's|/usr/share/bash-completion|${SNAP_TOOLBOX}/usr/share/bash-completion|g' \
-          ${SNAPCRAFT_PART_INSTALL}/etc/profile.d/bash_completion.sh
+          ${CRAFT_PART_INSTALL}/etc/profile.d/bash_completion.sh
       # source lxd bash completion if present
       echo "[ -f /snap/lxd/current/etc/bash_completion.d/snap.lxd.lxc ] && . /snap/lxd/current/etc/bash_completion.d/snap.lxd.lxc" \
-         >> ${SNAPCRAFT_PART_INSTALL}/etc/profile.d/bash_completion.sh
+         >> ${CRAFT_PART_INSTALL}/etc/profile.d/bash_completion.sh
       # source git-ondra bash completion if present
       echo "[ -f /snap/git-ondra/current/git-completion.bash ] && . /snap/git-ondra/current/git-completion.bash" \
-         >> ${SNAPCRAFT_PART_INSTALL}/etc/profile.d/bash_completion.sh
+         >> ${CRAFT_PART_INSTALL}/etc/profile.d/bash_completion.sh
       # source custom ssh if present
       echo "[ -f /snap/toolbox/current/usr/share/bash-completion/completions/ssh ] && . /snap/toolbox/current/usr/share/bash-completion/completions/ssh" \
-         >> ${SNAPCRAFT_PART_INSTALL}/etc/profile.d/bash_completion.sh
+         >> ${CRAFT_PART_INSTALL}/etc/profile.d/bash_completion.sh
       # fix pastebin to work with toolbox snap install
       sed -i \
           -e 's|/usr/local/etc/pastebin.d|/snap/toolbox/current/usr/share/pastebin.d|g' \
           -e 's/defaultPB = "pastebin.com"/defaultPB = "paste.ubuntu.com"/g' \
-          ${SNAPCRAFT_PART_INSTALL}/usr/bin/pastebinit
+          ${CRAFT_PART_INSTALL}/usr/bin/pastebinit
       # fix ssh_import_id search path for etc/ssh/ssh_import_id
       sed -i \
           -e 's|\(conf_file = "\)\(.*\)|\1/snap/toolbox/current\2|g' \
-          ${SNAPCRAFT_PART_INSTALL}/usr/lib/python3/dist-packages/ssh_import_id/__init__.py
+          ${CRAFT_PART_INSTALL}/usr/lib/python3/dist-packages/ssh_import_id/__init__.py
       # merge {s}bin/,lib, to usr/{s}bin, usr/lib
-      mv ${SNAPCRAFT_PART_INSTALL}/bin/*     ${SNAPCRAFT_PART_INSTALL}/usr/bin
-      mv ${SNAPCRAFT_PART_INSTALL}/sbin/*    ${SNAPCRAFT_PART_INSTALL}/usr/sbin
-      cp -rl ${SNAPCRAFT_PART_INSTALL}/lib/* ${SNAPCRAFT_PART_INSTALL}/usr/lib
-      rm -rf ${SNAPCRAFT_PART_INSTALL}/bin   ${SNAPCRAFT_PART_INSTALL}/sbin ${SNAPCRAFT_PART_INSTALL}/lib
-      ln -sf usr/bin  ${SNAPCRAFT_PART_INSTALL}/bin
-      ln -sf usr/sbin ${SNAPCRAFT_PART_INSTALL}/sbin
-      ln -sf usr/lib  ${SNAPCRAFT_PART_INSTALL}/lib
+      mv ${CRAFT_PART_INSTALL}/bin/*     ${CRAFT_PART_INSTALL}/usr/bin
+      mv ${CRAFT_PART_INSTALL}/sbin/*    ${CRAFT_PART_INSTALL}/usr/sbin
+      cp -rl ${CRAFT_PART_INSTALL}/lib/* ${CRAFT_PART_INSTALL}/usr/lib
+      rm -rf ${CRAFT_PART_INSTALL}/bin   ${CRAFT_PART_INSTALL}/sbin ${CRAFT_PART_INSTALL}/lib
+      ln -sf usr/bin  ${CRAFT_PART_INSTALL}/bin
+      ln -sf usr/sbin ${CRAFT_PART_INSTALL}/sbin
+      ln -sf usr/lib  ${CRAFT_PART_INSTALL}/lib
 
   mc:
     source: https://github.com/MidnightCommander/mc.git
@@ -210,20 +208,20 @@ parts:
       - --sysconfdir=/var/snap/toolbox/common/etc
       - --without-x
     override-build: |
-      snapcraftctl build
-      mv ${SNAPCRAFT_PART_INSTALL}/snap/toolbox/current/usr ${SNAPCRAFT_PART_INSTALL}/
-      rm -rf ${SNAPCRAFT_PART_INSTALL}/snap
-      mv ${SNAPCRAFT_PART_INSTALL}/var/snap/toolbox/common/etc ${SNAPCRAFT_PART_INSTALL}/
-      rm -rf ${SNAPCRAFT_PART_INSTALL}/var
+      craftctl default
+      mv ${CRAFT_PART_INSTALL}/snap/toolbox/current/usr ${CRAFT_PART_INSTALL}/
+      rm -rf ${CRAFT_PART_INSTALL}/snap
+      mv ${CRAFT_PART_INSTALL}/var/snap/toolbox/common/etc ${CRAFT_PART_INSTALL}/
+      rm -rf ${CRAFT_PART_INSTALL}/var
 
   macchanger:
     plugin: autotools
     source: https://github.com/alobbs/macchanger.git
     source-type: git
     autotools-configure-parameters:
-      - --datadir=/snap/${SNAPCRAFT_PROJECT_NAME}/current/usr/share/
+      - --datadir=/snap/${CRAFT_PROJECT_NAME}/current/usr/share/
     organize:
-      snap/${SNAPCRAFT_PROJECT_NAME}/current/usr/share/: usr/share/
+      snap/${CRAFT_PROJECT_NAME}/current/usr/share/: usr/share/
     stage:
       - -snap/
 
@@ -231,11 +229,11 @@ parts:
     plugin: nil
     source: https://github.com/micha/resty.git
     override-build: |
-      mkdir -p ${SNAPCRAFT_PART_INSTALL}/usr/bin
-      cp pp pypp ${SNAPCRAFT_PART_INSTALL}/usr/bin
-      cp resty ${SNAPCRAFT_PART_INSTALL}/usr/bin
-      mkdir -p ${SNAPCRAFT_PART_INSTALL}/usr/share/bash-completion/completions/
-      curl -o ${SNAPCRAFT_PART_INSTALL}/usr/share/bash-completion/completions/httpie https://raw.githubusercontent.com/jakubroztocil/httpie/master/extras/httpie-completion.bash
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/bin
+      cp pp pypp ${CRAFT_PART_INSTALL}/usr/bin
+      cp resty ${CRAFT_PART_INSTALL}/usr/bin
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/bash-completion/completions/
+      curl -o ${CRAFT_PART_INSTALL}/usr/share/bash-completion/completions/httpie https://raw.githubusercontent.com/jakubroztocil/httpie/master/extras/httpie-completion.bash
 
   rt-tests:
     source: https://git.kernel.org/pub/scm/linux/kernel/git/clrkwllms/rt-tests.git
@@ -247,7 +245,7 @@ parts:
     organize:
       usr/local/: usr/
     override-build: |
-      snapcraftctl build
+      craftctl default
     stage:
       - -usr/bin/hwlatdetect
 
@@ -256,31 +254,31 @@ parts:
     override-pull: |
       wget https://raw.githubusercontent.com/snapcore/snapd/master/tests/lib/tools/mountinfo.query
     override-build: |
-      cp mountinfo.query ${SNAPCRAFT_PART_INSTALL}/
+      cp mountinfo.query ${CRAFT_PART_INSTALL}/
     organize:
       mountinfo.query: usr/bin/mountinfo.query
 
   lk-boot-env:
     plugin: nil
     override-pull: |
-      snapcraftctl pull
+      craftctl default
       wget https://raw.githubusercontent.com/snapcore/snapd/master/include/lk/snappy_boot_common.h
       wget https://raw.githubusercontent.com/snapcore/snapd/master/include/lk/snappy_boot_v2.h
       wget https://raw.githubusercontent.com/kubiko/dragonboard-gadget/20-lk/snap-boot-sel/lk-boot-env.c
     override-build: |
-      mkdir -p ${SNAPCRAFT_PART_INSTALL}/usr/bin
-      gcc lk-boot-env.c -I/usr/include/ -Iapp/aboot -o ${SNAPCRAFT_PART_INSTALL}/usr/bin/lk-boot-env
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/bin
+      gcc lk-boot-env.c -I/usr/include/ -Iapp/aboot -o ${CRAFT_PART_INSTALL}/usr/bin/lk-boot-env
 
   mosh:
     plugin: autotools
     source: https://github.com/mobile-shell/mosh.git
     source-type: git
     stage-packages:
-      - libprotobuf17
+      - libprotobuf23
     autotools-configure-parameters:
       - --prefix=/usr
       - --bindir=/usr/bin
-      - --libdir=/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}
+      - --libdir=/usr/lib/${CRAFT_ARCH_TRIPLET}
     stage:
       - usr/bin/mosh-server
       - usr/bin/mosh
@@ -292,12 +290,12 @@ parts:
     source-type: git
     override-build: |
       make -j$(nproc)
-      install -D -m 0755 tiobench.pl         ${SNAPCRAFT_PART_INSTALL}/usr/bin/tiobench.pl
-      install -D -m 0755 tiotest             ${SNAPCRAFT_PART_INSTALL}/usr/bin/tiotest
-      install -D -m 0755 scripts/bigbench.sh ${SNAPCRAFT_PART_INSTALL}/usr/bin/bigbench.sh
-      install -D -m 0755 scripts/tiosum.pl   ${SNAPCRAFT_PART_INSTALL}/usr/bin/tiosum.pl
-      install -D -m 0644 README.md           ${SNAPCRAFT_PART_INSTALL}/usr/doc/tiobench/README.md
-      install -D -m 0644 scripts/README      ${SNAPCRAFT_PART_INSTALL}/usr/doc/tiobench/README
+      install -D -m 0755 tiobench.pl         ${CRAFT_PART_INSTALL}/usr/bin/tiobench.pl
+      install -D -m 0755 tiotest             ${CRAFT_PART_INSTALL}/usr/bin/tiotest
+      install -D -m 0755 scripts/bigbench.sh ${CRAFT_PART_INSTALL}/usr/bin/bigbench.sh
+      install -D -m 0755 scripts/tiosum.pl   ${CRAFT_PART_INSTALL}/usr/bin/tiosum.pl
+      install -D -m 0644 README.md           ${CRAFT_PART_INSTALL}/usr/doc/tiobench/README.md
+      install -D -m 0644 scripts/README      ${CRAFT_PART_INSTALL}/usr/doc/tiobench/README
 
   ioctl:
     plugin: make
@@ -306,7 +304,7 @@ parts:
     source-branch: master
     override-build: |
       if [ -z $(uname -a | grep "ppc64el") ]; then
-        snapcraftctl build
+        craftctl default
       fi
 
 build-packages:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -312,7 +312,9 @@ build-packages:
   - gawk
   - gettext
   - libboost-dev
+  - libext2fs-dev
   - libglib2.0-dev
+  - libgpm-dev
   - libltdl-dev
   - libncurses5-dev
   - libnuma-dev

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -97,6 +97,7 @@ parts:
       - parted
       - pastebinit
       - pciutils
+      - perl
       - ppp
       - psmisc
       - pv
@@ -129,12 +130,9 @@ parts:
         - sysbench
     stage:
       - -bin/bash
-      - -usr/bin/perl*
       - -usr/bin/py*
       - -usr/lib/gcc
       - -usr/lib/klibc*
-      - -usr/lib/*/perl*
-      - -usr/lib/*/libperl*
       - -usr/lib/python3/dist-packages/R*
       - -usr/lib/python3/dist-packages/c*
       - -usr/lib/python3/dist-packages/h*
@@ -147,7 +145,6 @@ parts:
       - -usr/share/doc
       - -usr/share/locale
       - -usr/share/man/
-      - -usr/share/perl*
       - -usr/share/python*
       - -usr/share/vim
       # make sure we do not have pulled in lsb_release, it makes no sense


### PR DESCRIPTION
If the `base:` field in `snapcraft.yaml` has a comment at the end of the line (as is the case for projects generated by `snapcraft init`) the current parsing method fails because the parsed `base` variable contains e.g. `core24#thebasesnapistheexecutionenvironmentforthissnap` which makes the subsequent case match fail and results in a Ubuntu 16 container being created.

To fix this, it would be enough to add `#` as a separator for `awk` ( `-F ':'` -> `-F '[:#]`).

I chose to instead grep the file for `^base:` to make it similar to the line for `build-base:` and to make it more readable.

This has been tested with multiple bases with and without comments at the end of the line.

(This time I also bumped the snap version number)